### PR TITLE
Fixed alpha calculation; included units in docs

### DIFF
--- a/libsettle/settle.cc
+++ b/libsettle/settle.cc
@@ -223,7 +223,10 @@ int mainer(double* flu, double* Z, double* X, double* mdo, int* docomp,
   //printf("Xbar=%lg, Q=%lg, Energy=%lg\n", Xbar, 1.6+4.0*Xbar,
   //       4*PI*G.R*G.R*y*9.64e17*(1.6+4.0*Xbar)/ZZ);
 
-  *alpha = 290. / (1.35 + 6.05 * Xbar);
+  // value of 290 was incorrect; correct calculation also depends on redshift
+  // updated prefactor is the mass energy of 1u
+  //*alpha = 290. / (1.35 + 6.05 * Xbar);
+  *alpha = 931.5 *(G.ZZ-1.)/G.ZZ / (1.35 + 6.05 * Xbar);
 
   *fluen = (4*M_PI*G.R*G.R*y*9.64e17*(1.35+6.05*Xbar)/G.ZZ)/1e39; //units of 1e39 erg/g
 

--- a/pySettle/__init__.py
+++ b/pySettle/__init__.py
@@ -5,5 +5,5 @@ settle module
 -------------------
 """
 __author__ = 'Andrew Cumming'
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 __date__ = '2023-03-16'

--- a/pySettle/__init__.py
+++ b/pySettle/__init__.py
@@ -5,5 +5,5 @@ settle module
 -------------------
 """
 __author__ = 'Andrew Cumming'
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 __date__ = '2023-03-16'

--- a/pySettle/settler.py
+++ b/pySettle/settler.py
@@ -44,10 +44,13 @@ class Settle(object):
         full: calls settle with all arguments, in case you want to change paramenters,
               it overrides the default F and C, but does not overwrite them
               Takes f, m, x, z, c
-              Returns alpha, trec, fluence
         run : more compact call, which assumes f and c from initialization.
               Takes m, x, and z
-              Returns alpha, trec, fluence
+
+        :param F: the flux from the bottom
+        :param C: include compressional heating (1) or not (0)
+
+        :return: alpha, trec [hr, observer frame], fluence [1e39 erg, observer frame]
         """
         #        path_to_data_file = (
         #            pathlib.Path(__file__).resolve().parent.parent / "settle" / "libsettle.so"

--- a/tests/test_settle_sft.py
+++ b/tests/test_settle_sft.py
@@ -38,7 +38,10 @@ def test_SFT():
         print("settl.full() test - check expected result.")
         res = settl.full(F=0.1, M=0.1, X=0.7, Z=0.02, C=0, R=11.2, Ma=1.4)
         print(res)
-        result = np.allclose(res, [66.32432920153866, 4.630885096736736, 7.516383459074593])
+        # updated here with the new (corrected) alpha calculation, for
+        # v0.1.3 and later
+        # result = np.allclose(res, [66.32432920153866, 4.630885096736736, 7.516383459074593])
+        result = np.allclose(res, [43.846559833302855, 4.630885096736736, 7.516383459074593])
         # alpha,tdel, E_b
     except:
         raise AssertionError("Settle SFT failed - some error occurred!")


### PR DESCRIPTION
The alpha calculation previously used an incorrect multiplier, and didn't take into account the varying mass and radius. Fixed both issues

Now also specifies the units for the recurrence time and burst energy in the comment